### PR TITLE
Update makefile

### DIFF
--- a/cache/cModel/makefile
+++ b/cache/cModel/makefile
@@ -1,7 +1,7 @@
 all: starflowModel
 
 starflowModel: starflowModel.cpp
-	g++ starflowModel.cpp -g -o starflowModel -lpcap -lpthread -std=c++11
+	g++ starflowModel.cpp -g -o starflowModel -lpcap -lpthread -latomic -std=c++11
 
 clean: 
 	rm starflowModel


### PR DESCRIPTION
Issue otherwise:

```
pi@raspberrypi:~/Desktop/StarFlow/cache/cModel $ ./example.sh 
g++ starflowModel.cpp -g -o starflowModel -lpcap -lpthread -std=c++11
starflowModel.cpp:42:20: warning: ISO C++ forbids converting a string constant to ‘char*’ [-Wwrite-strings]
 char *outputFile = "mCLFRs.bin";
                    ^~~~~~~~~~~~
/usr/bin/ld: /tmp/ccg4KbEY.o: in function `packetRoutine(OriginalPacket*)':
/usr/include/c++/8/bits/atomic_base.h:396: undefined reference to `__atomic_load_8'
/usr/bin/ld: /usr/include/c++/8/bits/atomic_base.h:434: undefined reference to `__atomic_compare_exchange_8'
/usr/bin/ld: /tmp/ccg4KbEY.o: in function `std::__atomic_base<unsigned long long>::operator++(int)':
/usr/include/c++/8/bits/atomic_base.h:514: undefined reference to `__atomic_fetch_add_8'
/usr/bin/ld: /tmp/ccg4KbEY.o: in function `std::__atomic_base<unsigned long long>::operator unsigned long long() const':
/usr/include/c++/8/bits/atomic_base.h:396: undefined reference to `__atomic_load_8'
collect2: error: ld returned 1 exit status
make: *** [makefile:4: starflowModel] Error 1
sudo: ./starflowModel: command not found
```